### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,3 +37,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: public
+    - name: Update Pages
+      run: |
+        curl -sS -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_PAGES_DEPLOY_TOKEN }}" \
+        https://api.github.com/repos/${{ github.repository }}/pages/builds \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,10 +3,13 @@ on:
     branches:
       - '!gh-pages'
       - '*'
-name: Build and Deploy
+
+name: Build, Test and Deploy
 jobs:
-  build-and-deploy:
-    name: Build and Deploy
+
+  # Fetch dependencies and build Gatsby
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -30,14 +33,56 @@ jobs:
       run: npm install
     - name: Build
       run: npm run build
-    - name: Deploy
-      if: github.ref == 'refs/heads/master'
+    - name: Save Build Artefact
+      uses: actions/upload-artifact@v1
+      with:
+        name: site-artefact
+        path: public
+
+  # Run unit tests on the artefact we just built.
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        fetch-depth: 1
+    - name: Download Website Artefact
+      uses: actions/download-artifact@v1
+      with:
+        name: site-artefact
+    - name: Restore Cached Dependencies
+      uses: actions/cache@v1
+      id: cache-node_modules
+      with:
+        path: node_modules
+        key: ${{ hashFiles('package.json') }}
+    - uses: actions/setup-node@master
+    - name: Reinstall Dependencies
+      run: npm install
+    - name: Run Tests
+      run: npm test
+
+  # Deploy to Github Pages environment
+  deploy-production:
+    name: Deploy to Production
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+    - name: Download Website Artefact
+      uses: actions/download-artifact@v1
+      with:
+        name: site-artefact
+    - name: Deploy to Github Pages
       uses: ./.github/actions/github-pages/
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: public
-    - name: Update Pages
+    - name: Trigger a Pages Update
       run: |
         curl -sS -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_PAGES_DEPLOY_TOKEN }}" \
         https://api.github.com/repos/${{ github.repository }}/pages/builds \

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
Now that builds are working again...

- Automate notifications to Github Pages API that a new release has occurred.
- Cache dependencies to speed up overall build time
- Artefact the generated website
- Fragment workflow into separate build, test and deploy steps